### PR TITLE
Update /v1/store urls to https when available.

### DIFF
--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/HttpRemoteStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/HttpRemoteStore.java
@@ -241,7 +241,12 @@ public class HttpRemoteStore
             this.httpClient = httpClient;
 
             // TODO: build URI from resource class
-            uri = URI.create(descriptor.getProperties().get("http") + "/v1/store/" + name);
+            if (descriptor.getProperties().get("https") != null) {
+                uri = URI.create(descriptor.getProperties().get("https") + "/v1/store/" + name);
+            }
+            else {
+                uri = URI.create(descriptor.getProperties().get("http") + "/v1/store/" + name);
+            }
         }
 
         @Override

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Replicator.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Replicator.java
@@ -129,7 +129,7 @@ public class Replicator
                 continue;
             }
 
-            String uri = descriptor.getProperties().get("http");
+            String uri = descriptor.getProperties().get("https") != null ? descriptor.getProperties().get("https") : descriptor.getProperties().get("http");
             if (uri == null) {
                 log.error("service descriptor for node %s is missing http uri", descriptor.getNodeId());
                 continue;


### PR DESCRIPTION
After turning on Https in Pretso - I noticed that we were still using HTTP urls for ```v1/store``` and this was leading to some errors. Updating these to use https when possible.

eg errors I saw in logs
```service descriptor for node is missing http uri```

```com.facebook.airlift.discovery.store.BatchProcessor Error handling batch java.lang.IllegalArgumentException: uri does not have a host: null/v1/store/dynamic```